### PR TITLE
Typed JSON decoding errors

### DIFF
--- a/example/src/Client.purs
+++ b/example/src/Client.purs
@@ -1,7 +1,6 @@
 module Client where
 
 import Prelude hiding (div)
-import Affjax (printError)
 import Control.Monad.Except.Trans (throwError)
 import Data.Either (Either(..))
 import Data.Foldable (foldMap)
@@ -12,7 +11,7 @@ import Effect.Exception (error)
 import JQuery (body, setHtml)
 import Site (site)
 import Text.Smolder.Renderer.String (render)
-import Type.Trout.Client (asClients)
+import Type.Trout.Client (asClients, printError)
 import Type.Trout.ContentType.HTML (encodeHTML)
 
 main :: Effect Unit


### PR DESCRIPTION
Hi, I'm following up on purescript-hyper/purescript-trout-client#15. This change will provide typed Argonaut errors as well as a `printError` function that can be used for both Affjax and Argonaut errors. Please let me know if there's anything you don't like about this solution so we can discuss and make changes as needed.